### PR TITLE
Fix the `create badges` part in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ yarn add --dev coverage-badge-creator
  3. Now you can create the badges.
  
     Add the command to your package.json scripts block:
-    ```sh
-    npm run coverage-badge-creator
+    ```json
+    "scripts": {
+      "coverage:badge": "coverage-badge-creator",
+    }   
     ```
     
     and run it from the CLI:
     ```sh
-    "scripts": {
-      "coverage:badge": "coverage-badge-creator",
-    }   
+    npm run coverage:badge
     ```
     
 


### PR DESCRIPTION
Seems the package.json scripts is put on the command area.
and the command didn't match the script name.